### PR TITLE
feat: harmonise naming style in Move stdlibs

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "substrate-stdlib"
+name = "SubstrateStdlib"
 version = "0.0.1"
 
 [addresses]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently, it contains the module:
 ## See also
 
 - [Pallet Move](https://github.com/eigerco/pallet-move)
+- [Move-stdlib](https://github.com/eigerco/move-stdlib)
 - [Substrate-Move](https://github.com/eigerco/substrate-move)
 - [smove](https://github.com/eigerco/smove)
 


### PR DESCRIPTION
- renamed stdlib from `substrate-stdlib` to `SubstrateStdlib` to harmonise naming style