### PR TITLE
feat: add new hash module with native functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository is part of [Pallet Move](https://github.com/eigerco/pallet-move)
 
 Currently, it contains the module:
 - __balance__: Supports the transfer of balances on the blockchain and checking current balances on accounts. Find more details in the [module documentation](doc/balance.md).
+- **substrate_hash**: Set of useful hash functions. Find more details in the [module documentation](doc/substrate_hash.md).
 
 ## See also
 

--- a/doc/substrate_hash.md
+++ b/doc/substrate_hash.md
@@ -1,0 +1,167 @@
+
+<a name="0x1_substrate_hash"></a>
+
+# Module `0x1::substrate_hash`
+
+Cryptographic hashes:
+- Keccak-256: see https://keccak.team/keccak.html
+
+In addition, SHA2-256 and SHA3-256 are available in <code>std::hash</code>. Note that SHA3-256 is a variant of Keccak: it is
+NOT the same as Keccak-256.
+
+Non-cryptograhic hashes:
+- SipHash: an add-rotate-xor (ARX) based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012
+
+
+-  [Function `sip_hash`](#0x1_substrate_hash_sip_hash)
+-  [Function `keccak256`](#0x1_substrate_hash_keccak256)
+-  [Function `sha2_512`](#0x1_substrate_hash_sha2_512)
+-  [Function `sha3_512`](#0x1_substrate_hash_sha3_512)
+-  [Function `ripemd160`](#0x1_substrate_hash_ripemd160)
+-  [Function `blake2b_256`](#0x1_substrate_hash_blake2b_256)
+
+
+<pre><code></code></pre>
+
+
+
+<a name="0x1_substrate_hash_sip_hash"></a>
+
+## Function `sip_hash`
+
+Returns the (non-cryptographic) SipHash of <code>bytes</code>. See https://en.wikipedia.org/wiki/SipHash
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_sip_hash">sip_hash</a>(bytes: vector&lt;u8&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_sip_hash">sip_hash</a>(bytes: vector&lt;u8&gt;): u64;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_substrate_hash_keccak256"></a>
+
+## Function `keccak256`
+
+Returns the Keccak-256 hash of <code>bytes</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_keccak256">keccak256</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_keccak256">keccak256</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_substrate_hash_sha2_512"></a>
+
+## Function `sha2_512`
+
+Returns the SHA2-512 hash of <code>bytes</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_sha2_512">sha2_512</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_sha2_512">sha2_512</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_substrate_hash_sha3_512"></a>
+
+## Function `sha3_512`
+
+Returns the SHA3-512 hash of <code>bytes</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_sha3_512">sha3_512</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_sha3_512">sha3_512</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_substrate_hash_ripemd160"></a>
+
+## Function `ripemd160`
+
+Returns the RIPEMD-160 hash of <code>bytes</code>.
+
+WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
+hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_ripemd160">ripemd160</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_ripemd160">ripemd160</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_substrate_hash_blake2b_256"></a>
+
+## Function `blake2b_256`
+
+Returns the BLAKE2B-256 hash of <code>bytes</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_blake2b_256">blake2b_256</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="substrate_hash.md#0x1_substrate_hash_blake2b_256">blake2b_256</a>(bytes: vector&lt;u8&gt;): vector&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>

--- a/sources/substrate_hash.move
+++ b/sources/substrate_hash.move
@@ -7,17 +7,6 @@
 /// Non-cryptograhic hashes:
 /// - SipHash: an add-rotate-xor (ARX) based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012
 module substrate::substrate_hash {
-    //
-    // Constants
-    //
-
-    /// A newly-added native function is not yet enabled.
-    const E_NATIVE_FUN_NOT_AVAILABLE: u64 = 1;
-
-    //
-    // Functions
-    //
-
     /// Returns the (non-cryptographic) SipHash of `bytes`. See https://en.wikipedia.org/wiki/SipHash
     native public fun sip_hash(bytes: vector<u8>): u64;
 

--- a/sources/substrate_hash.move
+++ b/sources/substrate_hash.move
@@ -1,0 +1,41 @@
+/// Cryptographic hashes:
+/// - Keccak-256: see https://keccak.team/keccak.html
+///
+/// In addition, SHA2-256 and SHA3-256 are available in `std::hash`. Note that SHA3-256 is a variant of Keccak: it is
+/// NOT the same as Keccak-256.
+///
+/// Non-cryptograhic hashes:
+/// - SipHash: an add-rotate-xor (ARX) based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012
+module substrate::substrate_hash {
+    //
+    // Constants
+    //
+
+    /// A newly-added native function is not yet enabled.
+    const E_NATIVE_FUN_NOT_AVAILABLE: u64 = 1;
+
+    //
+    // Functions
+    //
+
+    /// Returns the (non-cryptographic) SipHash of `bytes`. See https://en.wikipedia.org/wiki/SipHash
+    native public fun sip_hash(bytes: vector<u8>): u64;
+
+    /// Returns the Keccak-256 hash of `bytes`.
+    native public fun keccak256(bytes: vector<u8>): vector<u8>;
+
+    /// Returns the SHA2-512 hash of `bytes`.
+    native public fun sha2_512(bytes: vector<u8>): vector<u8>;
+
+    /// Returns the SHA3-512 hash of `bytes`.
+    native public fun sha3_512(bytes: vector<u8>): vector<u8>;
+
+    /// Returns the RIPEMD-160 hash of `bytes`.
+    ///
+    /// WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
+    /// hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
+    native public fun ripemd160(bytes: vector<u8>): vector<u8>;
+
+    /// Returns the BLAKE2B-256 hash of `bytes`.
+    native public fun blake2b_256(bytes: vector<u8>): vector<u8>;
+}


### PR DESCRIPTION
Added new set of hash functions within `substrate_hash` module:
```move
    native public fun sip_hash(bytes: vector<u8>): u64;
    native public fun keccak256(bytes: vector<u8>): vector<u8>;
    native public fun sha2_512(bytes: vector<u8>): vector<u8>;
    native public fun sha3_512(bytes: vector<u8>): vector<u8>;
    native public fun ripemd160(bytes: vector<u8>): vector<u8>;
    public fun blake2b_256(bytes: vector<u8>): vector<u8>;
```